### PR TITLE
Update lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           arguments: detektMain
       - name: "reviewdog-suggester: Suggest any code changes based on diff with reviewdog"
+        if: ${{ always() }}
         uses: reviewdog/action-suggester@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Lint失敗時もreviewdogを動作させるように Fix #72 