### PR TITLE
chore: Kotlin 2.0に対応

### DIFF
--- a/hideout-core/src/main/kotlin/dev/usbharu/hideout/activitypub/domain/model/Delete.kt
+++ b/hideout-core/src/main/kotlin/dev/usbharu/hideout/activitypub/domain/model/Delete.kt
@@ -26,8 +26,8 @@ open class Delete : Object, HasId, HasActor {
     @JsonProperty("object")
     val apObject: Object
     val published: String
-    override val actor: String
-    override val id: String
+    override var actor: String = ""
+    override var id: String = ""
 
     constructor(
         type: List<String> = emptyList(),

--- a/hideout-core/src/main/kotlin/dev/usbharu/hideout/application/infrastructure/exposed/ExposedPaginationExtension.kt
+++ b/hideout-core/src/main/kotlin/dev/usbharu/hideout/application/infrastructure/exposed/ExposedPaginationExtension.kt
@@ -18,10 +18,10 @@ package dev.usbharu.hideout.application.infrastructure.exposed
 
 import org.jetbrains.exposed.sql.*
 
-fun <S> Query.withPagination(page: Page, exp: ExpressionWithColumnType<S>): PaginationList<ResultRow, S> {
+fun <S : Any> Query.withPagination(page: Page, exp: ExpressionWithColumnType<S>): PaginationList<ResultRow, S> {
     page.limit?.let { limit(it) }
     val resultRows = if (page.minId != null) {
-        page.maxId?.let { andWhere { exp.less(it) } }
+        page.maxId?.let { it: Long -> andWhere { exp.less(it) } }
         andWhere { exp.greater(page.minId!!) }
         reversed()
     } else {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-kotlin = "1.9.24"
+kotlin = "2.0.0"
 ktor = "2.3.11"
 exposed = "0.50.1"
 javacv-ffmpeg = "6.1.1-1.5.10"

--- a/owl/build.gradle.kts
+++ b/owl/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+//    alias(libs.plugins.kotlin.jvm)
+    id("org.jetbrains.kotlin.jvm") version "1.9.24"
 }
 
 

--- a/owl/gradle.properties
+++ b/owl/gradle.properties
@@ -2,4 +2,4 @@ kotlin.code.style=official
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
-
+#ksp.useKSP2=true

--- a/owl/owl-broker/build.gradle.kts
+++ b/owl/owl-broker/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+//    alias(libs.plugins.kotlin.jvm)
+    kotlin("jvm")
     id("com.google.protobuf") version "0.9.4"
     id("com.google.devtools.ksp") version "1.9.24-1.0.20"
 }


### PR DESCRIPTION
OWLはKSPを使っていたのでKotlin 1.xのまま