### PR TITLE
fix: ResourceBundleが読み込めなく鳴っている問題を修正

### DIFF
--- a/hideout/build.gradle.kts
+++ b/hideout/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.spring.boot)
@@ -79,7 +81,11 @@ tasks {
             exclude("**/org/koin/ksp/generated/**", "**/generated/**")
         }
     }
-
+    named<BootJar>("bootJar") {
+        layered {
+            enabled.set(false)
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
マルチプロジェクト構成にした影響で、Spring BootのレイヤードJarとか言う謎の機能が影響してResourceBundleが読み込めなくなっていたので修正

レイヤードJarを無効化